### PR TITLE
fix(useField): Guard that `event` exist in `onChange` callback.

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -10,7 +10,7 @@ const subscriptionToInputs = subscription =>
   fieldSubscriptionItems.map(key => Boolean(subscription[key]))
 
 const eventValue = event => {
-  if (!event.target) {
+  if (!event || !event.target) {
     return event
   } else if (['checkbox', 'radio'].includes(event.target.type)) {
     return event.target.checked


### PR DESCRIPTION
Fixes `input.onChange` calls with `nil` values.