### PR TITLE
docs(README.md): Add `next` dist tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Need I say this? The React Hooks API is still very experimental and not recommen
 ## Installation
 
 ```bash
-npm install --save react-final-form-hooks final-form
+npm install --save react-final-form-hooks@next final-form
 ```
 
 or
 
 ```bash
-yarn add react-final-form-hooks final-form
+yarn add react-final-form-hooks@next final-form
 ```
 
 ## Getting Started


### PR DESCRIPTION
Latest (`1.0.0-alpha.2`) was published with `next` dist tag, so `yarn add react-final-form-hooks` will install `latest` (`1.0.0-alpha.1`) version.