### PR TITLE
[TS] Make useForm Config parameterized

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,12 +36,8 @@ export interface FieldRenderProps<V = any> {
   meta: NonFunctionProperties<FieldState>
 }
 
-interface FormConfig extends Config {
-  subscription?: FormSubscription
-}
-
 declare module 'react-final-form-hooks' {
-  export function useForm(config: FormConfig): FormRenderProps
+  export function useForm<C = FormConfig>(config: C): FormRenderProps
   export function useFormState(
     form: FormApi,
     subscription?: FormSubscription


### PR DESCRIPTION
This lets you define types for your `values` object on onSubmit. Here's a quick view what it looks like: 
```ts
  const { form, handleSubmit, submitting } = useForm<
    Config<{ title: string; description: string }>
  >({
    onSubmit: async values => {
```

Also, I got rid of the duplicate FormConfig interface.