### PR TITLE
Fix/cleanup effects

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -22,21 +22,21 @@ const eventValue = event => {
 const useField = (name, form, subscription = all) => {
   const autoFocus = useRef(false)
   const [state, setState] = useState({})
-  useEffect(
-    () =>
-      form.registerField(
-        name,
-        newState => {
-          if (autoFocus.current) {
-            autoFocus.current = false
-            setTimeout(() => newState.focus())
-          }
-          setState(newState)
-        },
-        subscription
-      ),
-    [name, form, ...subscriptionToInputs(subscription)]
-  )
+  useEffect(() => {
+    const unregisterField = form.registerField(
+      name,
+      newState => {
+        if (autoFocus.current) {
+          autoFocus.current = false
+          setTimeout(() => newState.focus())
+        }
+        setState(newState)
+      },
+      subscription
+    )
+
+    return () => unregisterField()
+  }, [name, form, ...subscriptionToInputs(subscription)])
   let { blur, change, focus, value, ...meta } = state || {}
   delete meta.name // it's in input
   return {

--- a/src/useField.test.js
+++ b/src/useField.test.js
@@ -2,18 +2,19 @@ import { renderHook, cleanup } from 'react-hooks-testing-library'
 import useField, { all } from './useField'
 
 describe('useField()', () => {
-  let form, name, subscription
+  let form, name, subscription, unregisterField
 
   beforeEach(() => {
     name = 'foo'
     subscription = { value: true }
+    unregisterField = jest.fn()
   })
   afterEach(cleanup)
 
   describe("form hook parameter's registerField", () => {
     beforeEach(() => {
       form = {
-        registerField: jest.fn()
+        registerField: jest.fn(() => unregisterField)
       }
     })
 
@@ -55,9 +56,10 @@ describe('useField()', () => {
       focus = jest.fn()
 
       form = {
-        registerField: jest.fn((name, callback, subscription) =>
+        registerField: jest.fn((name, callback, subscription) => {
           callback({ blur, change, focus, value })
-        )
+          return unregisterField
+        })
       }
     })
 
@@ -139,9 +141,10 @@ describe('useField()', () => {
       meta = { name: 'foo', bar: 'bar', biz: 'biz' }
 
       form = {
-        registerField: jest.fn((name, callback, subscription) =>
+        registerField: jest.fn((name, callback, subscription) => {
           callback({ ...meta })
-        )
+          return unregisterField
+        })
       }
     })
 

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -15,10 +15,11 @@ const subscriptionToInputs = subscription =>
 const useFormState = (form, subscription = all) => {
   const [state, setState] = useState(() => form.getState())
 
-  useEffect(() => form.subscribe(setState, subscription), [
-    form,
-    ...subscriptionToInputs(subscription)
-  ])
+  useEffect(() => {
+    const unsubscribe = form.subscribe(setState, subscription)
+
+    return () => unsubscribe()
+  }, [form, ...subscriptionToInputs(subscription)])
 
   return state
 }

--- a/src/useFormState.test.js
+++ b/src/useFormState.test.js
@@ -2,14 +2,18 @@ import { renderHook, cleanup, act } from 'react-hooks-testing-library'
 import useFormState, { all } from './useFormState'
 
 describe('useFormState()', () => {
-  let form, formState, setFormState, subscription
+  let form, formState, setFormState, subscription, unsubscribe
 
   beforeEach(() => {
-    subscription = { value: true }
     formState = { foo: 'foo' }
+    subscription = { value: true }
+    unsubscribe = jest.fn()
     form = {
       getState: jest.fn(() => formState),
-      subscribe: jest.fn((setState, subscription) => (setFormState = setState))
+      subscribe: jest.fn((setState, subscription) => {
+        setFormState = setState
+        return unsubscribe
+      })
     }
   })
   afterEach(cleanup)


### PR DESCRIPTION
This is a small change that adds a [cleanup](https://reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect) to two useEffect calls. It prevents possible memory leaks.
