### PR TITLE
Change event target type to checkbox on useField test

### DIFF
--- a/src/useField.test.js
+++ b/src/useField.test.js
@@ -109,7 +109,7 @@ describe('useField()', () => {
       })
 
       describe('when event has a checked prop', () => {
-        const event = { target: { type: 'radio', checked: false } }
+        const event = { target: { type: 'checkbox', checked: false } }
 
         it('calls provided handler with value', () => {
           const { onChange } = setupHook()


### PR DESCRIPTION
A recent fix (#38) ends up breaking a test on useField because we used radio as input type. This will update it so it works again.