### PR TITLE
useForm config not generic + pass form values to config

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,7 +15,7 @@ export interface FormRenderProps<S> extends FormState<S> {
   ) => Promise<object | undefined> | undefined
 }
 
-interface FormConfig extends Config {
+interface FormConfig<FormValues> extends Config<FormValues> {
   subscription?: FormSubscription
   initialValuesEqual?: (a: object, b: object) => boolean
 }
@@ -38,7 +38,7 @@ export interface FieldRenderProps<V = any, T = string> {
 }
 
 declare module 'react-final-form-hooks' {
-  export function useForm<C = FormConfig, S = object>(config: C): FormRenderProps<S>
+  export function useForm<S = object>(config: FormConfig<S>): FormRenderProps<S>
   export function useFormState<S = object>(
     form: FormApi<S>,
     subscription?: FormSubscription


### PR DESCRIPTION
Just a couple small tweaks to the typescript file. 
1) The config being a generic meant it accepted any argument, this changes it so it's typed as config so you will get errors passing an invalid config.
2) Pass the form values along to the final-form config type. 